### PR TITLE
fix(#58): stilo forigi accepts multiple UUIDs

### DIFF
--- a/src/A_agento/stilo.py
+++ b/src/A_agento/stilo.py
@@ -112,38 +112,43 @@ def listo() -> None:
 
 
 @stilo_app.command("forigi", help=tr_multi(
-    "Forigi skribstilan specimon",  # eo
-    "Remove a style sample",  # en
-    "Supprimer un echantillon de style",  # fr
+    "Forigi skribstilajn specimojn",  # eo
+    "Remove style samples",  # en
+    "Supprimer les échantillons de style",  # fr
 ))
 def forigi(
-    uuid: str = typer.Argument(
+    uuids: list[str] = typer.Argument(
         ...,
         help=tr_multi(
-            "Specimo UUID",  # eo
-            "Sample UUID",  # en
-            "UUID de l'échantillon",  # fr
+            "Specimo UUID-oj (pluraj)",  # eo
+            "Sample UUIDs (multiple)",  # en
+            "UUID des échantillons (plusieurs)",  # fr
         ),
     ),
 ) -> None:
-    """Remove a style sample."""
-    delete_style_sample(uuid)
-    success(tr_multi('Specimo forigita.', 'Sample deleted.', 'Echantillon supprime.'))  # Sample deleted
+    """Remove style samples."""
+    for uid in uuids:
+        delete_style_sample(uid)
+    success(tr_multi(
+        f"Forigis {len(uuids)} specimojn.",
+        f"Deleted {len(uuids)} samples.",
+        f"Supprimé {len(uuids)} échantillons.",
+    ))
 
 
 @stilo_app.command("forigu", hidden=True)
 def forigu(
-    uuid: str = typer.Argument(
+    uuids: list[str] = typer.Argument(
         ...,
         help=tr_multi(
-            "Specimo UUID",  # eo
-            "Sample UUID",  # en
-            "UUID de l'échantillon",  # fr
+            "Specimo UUID-oj (pluraj)",  # eo
+            "Sample UUIDs (multiple)",  # en
+            "UUID des échantillons (plusieurs)",  # fr
         ),
     ),
 ) -> None:
     """[DEPRECATED] Use 'stilo forigi' instead."""
-    forigi(uuid)
+    forigi(uuids)
 
 
 @stilo_app.command("aktiva", help=tr_multi(

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -98,6 +98,41 @@ class TestAgordoCommand:
         assert result.exit_code == 0
 
 
+class TestStiloCommand:
+    """Tests for stilo (style sample) commands."""
+
+    def test_stilo_shows_help(self):
+        """Test stilo command shows help."""
+        result = runner.invoke(app, ["stilo", "--help"])
+        assert result.exit_code == 0
+        assert "stilo" in result.output.lower()
+
+    @patch("A_agento.stilo.delete_style_sample")
+    def test_forigi_single(self, mock_del):
+        """Test forigi with a single UUID."""
+        result = runner.invoke(app, ["stilo", "forigi", "abc12345"])
+        assert result.exit_code == 0
+        mock_del.assert_called_once_with("abc12345")
+
+    @patch("A_agento.stilo.delete_style_sample")
+    def test_forigi_multiple(self, mock_del):
+        """Test forigi with multiple UUIDs."""
+        result = runner.invoke(app, ["stilo", "forigi", "abc12345", "def67890"])
+        assert result.exit_code == 0
+        assert mock_del.call_count == 2
+        mock_del.assert_any_call("abc12345")
+        mock_del.assert_any_call("def67890")
+
+    @patch("A_agento.stilo.delete_style_sample")
+    def test_forigu_multiple(self, mock_del):
+        """Test deprecated forigu with multiple UUIDs."""
+        result = runner.invoke(app, ["stilo", "forigu", "abc12345", "def67890"])
+        assert result.exit_code == 0
+        assert mock_del.call_count == 2
+        mock_del.assert_any_call("abc12345")
+        mock_del.assert_any_call("def67890")
+
+
 class TestApp:
     """General app tests."""
 


### PR DESCRIPTION
## What

Changes `stilo forigi` (and deprecated `forigu`) from single `uuid: str` to `uuids: list[str]`, supporting batch deletion of style samples in one command.

## Why

Fixes #58 — the `stilo forigi` contract requires accepting multiple identifiers. Single-UUID was inconsistent with other `forigi` commands.

## How

- `forigi` iterates over all provided UUIDs, calling `delete_style_sample` for each
- `forigu` (deprecated alias) delegates to `forigi` with updated signature
- Tests: single, multi-UUID, and deprecated alias paths

## Verification

- 152 tests pass
- User-simulation: `stilo forigi abc def ghi` deletes all 3