### PR TITLE
fix: replace raw pip install chain with ensure_dependency('trafilatura')

### DIFF
--- a/src/A_agento/commands/_context_helpers.py
+++ b/src/A_agento/commands/_context_helpers.py
@@ -4,7 +4,7 @@ from pathlib import Path
 
 import typer
 
-from A import tr_multi, info, success, warning
+from A import tr_multi, success, warning
 
 _core_html_to_text = None
 try:
@@ -78,54 +78,21 @@ def _offer_trafilatura_if_missing() -> None:
     try:
         import trafilatura  # noqa: F401
     except ImportError:
-        import sys
+        from A.utils.deps import ensure_dependency
 
-        if typer.confirm(
-            tr_multi(
-                "Ĉu instali trafilatura (A-core[web]) por pli bona "
-                "enhavo-eltiro el retpaĝoj?",
-                "Install trafilatura (A-core[web]) for better "
-                "web page content extraction?",
-                "Installer trafilatura (A-core[web]) pour une meilleure "
-                "extraction du contenu web ?",
-            ),
-            default=True,
-        ):
-            info(tr_multi(
-                "Instalas trafilatura...",
-                "Installing trafilatura...",
-                "Installation de trafilatura...",
+        try:
+            ensure_dependency("trafilatura")
+            success(tr_multi(
+                "trafilatura instalita. Rekomencu la ordon por uzi ghin.",
+                "trafilatura installed. Restart the command to use it.",
+                "trafilatura installé. Réexécutez la commande pour l'utiliser.",
             ))
-            try:
-                import subprocess
-
-                installers = [
-                    ("uv pip", ["uv", "pip", "install", "trafilatura"]),
-                    ("pip", ["pip", "install", "trafilatura"]),
-                    ("python3 -m pip", ["python3", "-m", "pip", "install", "trafilatura"]),
-                    (f"{sys.executable} -m pip", [sys.executable, "-m", "pip", "install", "trafilatura"]),
-                ]
-                for label, cmd in installers:
-                    try:
-                        subprocess.check_call(
-                            cmd, stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL,
-                        )
-                        success(tr_multi(
-                            "trafilatura instalita. Rekomencu la ordon por uzi ghin.",
-                            "trafilatura installed. Restart the command to use it.",
-                            "trafilatura installé. Réexécutez la commande pour l'utiliser.",
-                        ))
-                        return
-                    except (FileNotFoundError, subprocess.CalledProcessError):
-                        continue
-
-                warning(tr_multi(
-                    "Ne eblis instali trafilatura per iu ajn metodo. "
-                    "Provu permane: uv pip install trafilatura",
-                    "Could not install trafilatura via any method. "
-                    "Try manually: uv pip install trafilatura",
-                    "Impossible d'installer trafilatura. "
-                    "Essayez manuellement : uv pip install trafilatura",
-                ))
-            except Exception:
-                pass
+        except ImportError:
+            warning(tr_multi(
+                "Ne eblis instali trafilatura. "
+                "Provu permane: uv pip install trafilatura",
+                "Could not install trafilatura. "
+                "Try manually: uv pip install trafilatura",
+                "Impossible d'installer trafilatura. "
+                "Essayez manuellement : uv pip install trafilatura",
+            ))

--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -283,3 +283,52 @@ class TestFallbackWithContext:
             [],
         )
         assert result == "Generated text"
+
+
+class TestOfferTrafilatura:
+    """_offer_trafilatura_if_missing delegates to ensure_dependency."""
+
+    def test_trafilatura_available(self) -> None:
+        """When trafilatura is already importable, no install needed."""
+        from A_agento.commands._context_helpers import _offer_trafilatura_if_missing
+
+        import types
+        mock_mod = types.ModuleType("trafilatura")
+        with patch.dict("sys.modules", {"trafilatura": mock_mod}):
+            # Should return without attempting install
+            _offer_trafilatura_if_missing()
+
+    def test_calls_ensure_dependency(self) -> None:
+        """When missing, calls ensure_dependency('trafilatura')."""
+        from A_agento.commands._context_helpers import _offer_trafilatura_if_missing
+
+        import builtins
+        original_import = builtins.__import__
+
+        def fake_import(name, *args, **kwargs):
+            if name == "trafilatura":
+                raise ImportError
+            return original_import(name, *args, **kwargs)
+
+        with patch.object(builtins, "__import__", fake_import):
+            with patch("A.utils.deps.ensure_dependency") as mock_ed:
+                _offer_trafilatura_if_missing()
+                mock_ed.assert_called_once_with("trafilatura")
+
+    def test_import_error_shows_warning(self) -> None:
+        """When ensure_dependency fails, shows warning instead of crashing."""
+        from A_agento.commands._context_helpers import _offer_trafilatura_if_missing
+
+        import builtins
+        original_import = builtins.__import__
+
+        def fake_import(name, *args, **kwargs):
+            if name == "trafilatura":
+                raise ImportError
+            return original_import(name, *args, **kwargs)
+
+        with patch.object(builtins, "__import__", fake_import):
+            with patch("A.utils.deps.ensure_dependency", side_effect=ImportError("fail")):
+                with patch("A_agento.commands._context_helpers.warning") as mock_warn:
+                    _offer_trafilatura_if_missing()
+                    mock_warn.assert_called_once()


### PR DESCRIPTION
Replace 4-level manual fallback chain (uv pip → pip → python3 -m pip → sys.executable -m pip) with `A.utils.deps.ensure_dependency('trafilatura')` which already implements uv-first priority.

- Remove unused 'info' import
- Add tests: fast path, delegation, warning on failure

Refs: #16