### PR TITLE
refactor: standardize singleton naming and remove intermediate path vars (#21)

### DIFF
--- a/src/A_agento/data/_storage_base.py
+++ b/src/A_agento/data/_storage_base.py
@@ -64,25 +64,25 @@ _SCHEMA: dict[str, str] = {
     """,
 }
 
-_db: SQLiteDB | None = None
+_db_instance: SQLiteDB | None = None
 
 
 def get_db() -> SQLiteDB:
-    global _db
-    if _db is None:
+    global _db_instance
+    if _db_instance is None:
         db_path = data_dir() / f"{_DB_NAME}.db"
         if not health_check(db_path):
             from A.data.base import repair_db as _repair
             _repair(db_path)
         backup_db(db_path)
-        _db = SQLiteDB(db_path, schema=_SCHEMA)
-    return _db
+        _db_instance = SQLiteDB(db_path, schema=_SCHEMA)
+    return _db_instance
 
 
 def close_db() -> None:
-    global _db
-    if _db is not None:
-        _db = None
+    global _db_instance
+    if _db_instance is not None:
+        _db_instance = None
 
 
 def get_backup_targets() -> list[BackupTarget]:


### PR DESCRIPTION
### Summary

Implements the 5-phase plan from issue #21:

**Phase 1a** — A-semantika: renamed `_DB` → `_db_instance` in `storage.py` + test files
**Phase 1b** — A-agento: renamed `_db` → `_db_instance` in `_storage_base.py`
**Phase 2** — A-encik, A-vorto, A-organizi, A-medio: removed `_DATA_DIR`/`_DB_FILE` intermediate variables, inlined `data_dir()` calls
**Phase 3** — A-core: added `simulate()` context manager to `A.core.testing` with safety guard

### Testing

- ✅ All existing tests pass (450 A-core, 136 A-encik, 125 A-vorto, 307 A-organizi, 155 A-medio, 155 A-agento, 670 A-semantika)
- ✅ User-simulation smoke tests: 10/11 CLI commands work with `A_DIR` isolation (1 pre-existing: A-organizi has no top-level `ls`)
- ✅ `simulate()` context manager verified: sets `A_DIR`, validates isolation, restores on exit